### PR TITLE
Fix some issues with the mythicbotany aiots

### DIFF
--- a/src/main/java/de/melanx/aiotbotania/items/alfsteel/ItemAlfsteelAIOT.java
+++ b/src/main/java/de/melanx/aiotbotania/items/alfsteel/ItemAlfsteelAIOT.java
@@ -104,8 +104,19 @@ public class ItemAlfsteelAIOT extends ItemTerraSteelAIOT implements MythicBotany
     }
 
     @Override
+    public boolean canRepairPylon(ItemStack stack) {
+        return stack.getDamage() > 0;
+    }
+
+    @Override
     public int getRepairManaPerTick(ItemStack stack) {
-        return MANA_PER_DAMAGE / 2; // Alftools need half on the mana required normally on the pylon.
+        return (int) (2.5 * MANA_PER_DAMAGE);
+    }
+
+    @Override
+    public ItemStack repairOneTick(ItemStack stack) {
+        stack.setDamage(Math.max(0, stack.getDamage() - 5));
+        return stack;
     }
 
     @Override

--- a/src/main/java/de/melanx/aiotbotania/items/alfsteel/ItemAlfsteelAIOT.java
+++ b/src/main/java/de/melanx/aiotbotania/items/alfsteel/ItemAlfsteelAIOT.java
@@ -48,7 +48,6 @@ public class ItemAlfsteelAIOT extends ItemTerraSteelAIOT implements MythicBotany
 
     public ItemAlfsteelAIOT() {
         super(ItemTiers.ALFSTEEL_AIOT_ITEM_TIER);
-        MinecraftForge.EVENT_BUS.addListener(this::leftClick);
         ImmutableMultimap.Builder<Attribute, AttributeModifier> builder = ImmutableMultimap.builder();
         builder.put(Attributes.ATTACK_DAMAGE, new AttributeModifier(ATTACK_DAMAGE_MODIFIER, "Weapon modifier", getAttackDamage(), AttributeModifier.Operation.ADDITION));
         builder.put(Attributes.ATTACK_SPEED, new AttributeModifier(ATTACK_SPEED_MODIFIER, "Weapon modifier", 2.4, AttributeModifier.Operation.ADDITION));
@@ -75,12 +74,6 @@ public class ItemAlfsteelAIOT extends ItemTerraSteelAIOT implements MythicBotany
             }
         }
         return super.onItemRightClick(world, player, hand);
-    }
-
-    private void leftClick(PlayerInteractEvent.LeftClickEmpty evt) {
-        if (!evt.getItemStack().isEmpty() && evt.getItemStack().getItem() == this) {
-            mythicbotany.MythicBotany.getNetwork().instance.sendToServer(new mythicbotany.network.AlfSwordLeftClickSerializer.AlfSwordLeftClickMessage());
-        }
     }
 
     @Override

--- a/src/main/java/de/melanx/aiotbotania/items/alfsteel/ItemAlfsteelAIOT.java
+++ b/src/main/java/de/melanx/aiotbotania/items/alfsteel/ItemAlfsteelAIOT.java
@@ -6,17 +6,22 @@ import de.melanx.aiotbotania.AIOTBotania;
 import de.melanx.aiotbotania.compat.MythicBotany;
 import de.melanx.aiotbotania.items.ItemTiers;
 import de.melanx.aiotbotania.items.terrasteel.ItemTerraSteelAIOT;
+import net.minecraft.block.material.Material;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.ai.attributes.Attribute;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.ai.attributes.Attributes;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.Direction;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.vector.Vector3i;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.TranslationTextComponent;
@@ -24,7 +29,12 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.fml.ModList;
+import vazkii.botania.common.core.helper.PlayerHelper;
 import vazkii.botania.common.entity.EntityManaBurst;
+import vazkii.botania.common.item.ItemTemperanceStone;
+import vazkii.botania.common.item.equipment.tool.ToolCommons;
+import vazkii.botania.common.item.relic.ItemThorRing;
+import vazkii.botania.common.lib.ResourceLocationHelper;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -102,13 +112,47 @@ public class ItemAlfsteelAIOT extends ItemTerraSteelAIOT implements MythicBotany
 
     @Override
     public int getRepairManaPerTick(ItemStack stack) {
-        return MANA_PER_DAMAGE;
+        return MANA_PER_DAMAGE / 2; // Alftools need half on the mana required normally on the pylon.
     }
 
     @Override
-    public void addInformation(@Nonnull ItemStack stack, @Nullable World worldIn, @Nonnull List<ITextComponent> tooltip, @Nonnull ITooltipFlag flagIn) {
+    public void breakOtherBlock(PlayerEntity player, ItemStack stack, BlockPos pos, BlockPos originPos, Direction side) {
+        if (isEnabled(stack)) {
+            World world = player.world;
+            Material mat = world.getBlockState(pos).getMaterial();
+            if (MATERIALS.contains(mat) && !world.isAirBlock(pos)) {
+                boolean thor = !ItemThorRing.getThorRing(player).isEmpty();
+                boolean doX = thor || side.getXOffset() == 0;
+                boolean doY = thor || side.getYOffset() == 0;
+                boolean doZ = thor || side.getZOffset() == 0;
+                int origLevel = getLevel(stack);
+                int level = origLevel + (thor ? 1 : 0);
+                int rangeDepth = level / 2;
+                if (ItemTemperanceStone.hasTemperanceActive(player) && level > 2) {
+                    level = 2;
+                    rangeDepth = 0;
+                }
+
+                int range = level - 1;
+                int rangeY = Math.max(1, range);
+                if (range != 0 || level == 1) {
+                    Vector3i beginDiff = new Vector3i(doX ? -range : 0, doY ? -1 : 0, doZ ? -range : 0);
+                    Vector3i endDiff = new Vector3i(doX ? range : rangeDepth * -side.getXOffset(), doY ? rangeY * 2 - 1 : 0, doZ ? range : rangeDepth * -side.getZOffset());
+                    ToolCommons.removeBlocksInIteration(player, stack, world, pos, beginDiff, endDiff, (state) -> MATERIALS.contains(state.getMaterial()), isTipped(stack));
+                    if (origLevel == 5) {
+                        PlayerHelper.grantCriterion((ServerPlayerEntity)player, ResourceLocationHelper.prefix("challenge/rank_ss_pick"), "code_triggered");
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void addInformation(@Nonnull ItemStack stack, @Nullable World world, @Nonnull List<ITextComponent> tooltip, @Nonnull ITooltipFlag flag) {
         if (!ModList.get().isLoaded("mythicbotany")) {
             tooltip.add(new TranslationTextComponent(AIOTBotania.MODID + ".mythicbotany.disabled").mergeStyle(TextFormatting.DARK_RED));
+        } else {
+            super.addInformation(stack, world, tooltip, flag);
         }
     }
 }

--- a/src/main/java/de/melanx/aiotbotania/items/alfsteel/ItemAlfsteelHoe.java
+++ b/src/main/java/de/melanx/aiotbotania/items/alfsteel/ItemAlfsteelHoe.java
@@ -38,13 +38,15 @@ public class ItemAlfsteelHoe extends ItemTerraHoe implements MythicBotany, ModPy
 
     @Override
     public int getRepairManaPerTick(ItemStack stack) {
-        return MANA_PER_DAMAGE;
+        return MANA_PER_DAMAGE / 2;  // Alftools need half on the mana required normally on the pylon.
     }
 
     @Override
-    public void addInformation(@Nonnull ItemStack stack, @Nullable World worldIn, @Nonnull List<ITextComponent> tooltip, @Nonnull ITooltipFlag flagIn) {
+    public void addInformation(@Nonnull ItemStack stack, @Nullable World world, @Nonnull List<ITextComponent> tooltip, @Nonnull ITooltipFlag flag) {
         if (!ModList.get().isLoaded("mythicbotany")) {
             tooltip.add(new TranslationTextComponent(AIOTBotania.MODID + ".mythicbotany.disabled").mergeStyle(TextFormatting.DARK_RED));
+        } else {
+            super.addInformation(stack, world, tooltip, flag);
         }
     }
 }

--- a/src/main/java/de/melanx/aiotbotania/items/alfsteel/ItemAlfsteelHoe.java
+++ b/src/main/java/de/melanx/aiotbotania/items/alfsteel/ItemAlfsteelHoe.java
@@ -37,8 +37,19 @@ public class ItemAlfsteelHoe extends ItemTerraHoe implements MythicBotany, ModPy
     }
 
     @Override
+    public boolean canRepairPylon(ItemStack stack) {
+        return stack.getDamage() > 0;
+    }
+
+    @Override
     public int getRepairManaPerTick(ItemStack stack) {
-        return MANA_PER_DAMAGE / 2;  // Alftools need half on the mana required normally on the pylon.
+        return (int) (2.5 * MANA_PER_DAMAGE);
+    }
+
+    @Override
+    public ItemStack repairOneTick(ItemStack stack) {
+        stack.setDamage(Math.max(0, stack.getDamage() - 5));
+        return stack;
     }
 
     @Override

--- a/src/main/java/de/melanx/aiotbotania/items/alfsteel/ItemAlfsteelShovel.java
+++ b/src/main/java/de/melanx/aiotbotania/items/alfsteel/ItemAlfsteelShovel.java
@@ -43,8 +43,19 @@ public class ItemAlfsteelShovel extends ItemTerraShovel implements MythicBotany,
     }
 
     @Override
+    public boolean canRepairPylon(ItemStack stack) {
+        return stack.getDamage() > 0;
+    }
+
+    @Override
     public int getRepairManaPerTick(ItemStack stack) {
-        return MANA_PER_DAMAGE / 2; // Alftools need half on the mana required normally on the pylon.
+        return (int) (2.5 * MANA_PER_DAMAGE);
+    }
+
+    @Override
+    public ItemStack repairOneTick(ItemStack stack) {
+        stack.setDamage(Math.max(0, stack.getDamage() - 5));
+        return stack;
     }
 
     @Override

--- a/src/main/java/de/melanx/aiotbotania/items/alfsteel/ItemAlfsteelShovel.java
+++ b/src/main/java/de/melanx/aiotbotania/items/alfsteel/ItemAlfsteelShovel.java
@@ -44,13 +44,15 @@ public class ItemAlfsteelShovel extends ItemTerraShovel implements MythicBotany,
 
     @Override
     public int getRepairManaPerTick(ItemStack stack) {
-        return MANA_PER_DAMAGE;
+        return MANA_PER_DAMAGE / 2; // Alftools need half on the mana required normally on the pylon.
     }
 
     @Override
-    public void addInformation(@Nonnull ItemStack stack, @Nullable World worldIn, @Nonnull List<ITextComponent> tooltip, @Nonnull ITooltipFlag flagIn) {
+    public void addInformation(@Nonnull ItemStack stack, @Nullable World world, @Nonnull List<ITextComponent> tooltip, @Nonnull ITooltipFlag flag) {
         if (!ModList.get().isLoaded("mythicbotany")) {
             tooltip.add(new TranslationTextComponent(AIOTBotania.MODID + ".mythicbotany.disabled").mergeStyle(TextFormatting.DARK_RED));
+        } else {
+            super.addInformation(stack, world, tooltip, flag);
         }
     }
 }

--- a/src/main/java/de/melanx/aiotbotania/items/terrasteel/ItemTerraSteelAIOT.java
+++ b/src/main/java/de/melanx/aiotbotania/items/terrasteel/ItemTerraSteelAIOT.java
@@ -65,7 +65,7 @@ public class ItemTerraSteelAIOT extends ItemAIOTBase implements ISequentialBreak
     public static final int MANA_PER_DAMAGE = 100;
     public static final float DAMAGE = 6.0F;
     public static final float SPEED = -2.2F;
-    private static final List<Material> MATERIALS = Arrays.asList(Material.ROCK, Material.IRON, Material.ICE, Material.GLASS, Material.PISTON, Material.ANVIL, Material.ORGANIC, Material.EARTH, Material.SAND, Material.SNOW, Material.SNOW_BLOCK, Material.CLAY);
+    protected static final List<Material> MATERIALS = Arrays.asList(Material.ROCK, Material.IRON, Material.ICE, Material.GLASS, Material.PISTON, Material.ANVIL, Material.ORGANIC, Material.EARTH, Material.SAND, Material.SNOW, Material.SNOW_BLOCK, Material.CLAY);
     private static final List<Material> AXE_MATERIALS = Arrays.asList(Material.WOOD, Material.LEAVES, Material.BAMBOO);
     public static final int[] LEVELS = new int[]{0, 10000, 1000000, 10000000, 100000000, 1000000000};
     private static final int[] CREATIVE_MANA = new int[]{9999, 999999, 9999999, 99999999, 999999999, Integer.MAX_VALUE};


### PR DESCRIPTION
  * Tooltip is now shown for the Alfsteel AIOT
  * The AIOT now breaks multiple blocks in the direction you're looking, just as the alfsteel pick.
  * Removed the useless `leftClick` method in the Alfsteel AIOT class
  * The new alfsteel tools only require half of the usual mana when repaired on an alfsteel pylon. (Like all other alfsteel tools do)