### PR TITLE
Made the Terrasteel AIOT less annoying

### DIFF
--- a/src/main/java/de/melanx/aiotbotania/items/terrasteel/ItemTerraSteelAIOT.java
+++ b/src/main/java/de/melanx/aiotbotania/items/terrasteel/ItemTerraSteelAIOT.java
@@ -14,7 +14,6 @@ import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.Enchantments;
-import net.minecraft.entity.ai.RandomPositionGenerator;
 import net.minecraft.entity.ai.attributes.Attribute;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.item.ItemEntity;

--- a/src/main/java/de/melanx/aiotbotania/items/terrasteel/ItemTerraSteelAIOT.java
+++ b/src/main/java/de/melanx/aiotbotania/items/terrasteel/ItemTerraSteelAIOT.java
@@ -14,6 +14,7 @@ import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.Enchantments;
+import net.minecraft.entity.ai.RandomPositionGenerator;
 import net.minecraft.entity.ai.attributes.Attribute;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.item.ItemEntity;
@@ -316,7 +317,7 @@ public class ItemTerraSteelAIOT extends ItemAIOTBase implements ISequentialBreak
                 int rangeY = Math.max(1, range);
                 if (range != 0 || level == 1) {
                     Vector3i beginDiff = new Vector3i(doX ? -range : 0, doY ? -1 : 0, doZ ? -range : 0);
-                    Vector3i endDiff = new Vector3i(doX ? range : rangeDepth * -side.getXOffset(), doY ? rangeY * 2 - 1 : 0, doZ ? range : rangeDepth * -side.getZOffset());
+                    Vector3i endDiff = new Vector3i(doX ? range : 0, doY ? rangeY * 2 - 1 : 0, doZ ? range : 0);
                     ToolCommons.removeBlocksInIteration(player, stack, world, pos, beginDiff, endDiff,
                             state -> stack.getDestroySpeed(state) > 1.0F || MATERIALS.contains(state.getMaterial()));
                     if (origLevel == 5) {

--- a/src/main/java/de/melanx/aiotbotania/items/terrasteel/ItemTerraSteelAIOT.java
+++ b/src/main/java/de/melanx/aiotbotania/items/terrasteel/ItemTerraSteelAIOT.java
@@ -307,10 +307,8 @@ public class ItemTerraSteelAIOT extends ItemAIOTBase implements ISequentialBreak
                 boolean doZ = thor || side.getZOffset() == 0;
                 int origLevel = getLevel(stack);
                 int level = origLevel + (thor ? 1 : 0);
-                int rangeDepth = level / 2;
                 if (ItemTemperanceStone.hasTemperanceActive(player) && level > 2) {
                     level = 2;
-                    rangeDepth = 0;
                 }
 
                 int range = level - 1;

--- a/src/main/java/de/melanx/aiotbotania/items/terrasteel/ItemTerraSteelAIOT.java
+++ b/src/main/java/de/melanx/aiotbotania/items/terrasteel/ItemTerraSteelAIOT.java
@@ -328,7 +328,7 @@ public class ItemTerraSteelAIOT extends ItemAIOTBase implements ISequentialBreak
     }
 
     public void breakOtherBlockAxe(PlayerEntity player, ItemStack stack, BlockPos pos, @SuppressWarnings("unused") BlockPos originPos, @SuppressWarnings("unused") Direction side) {
-        if (!player.isSneaking() && !tickingSwappers) {
+    	if (!player.isSneaking() && !tickingSwappers && isEnabled(stack)) {
             addBlockSwapper(player.world, player, stack, pos, 32, true);
         }
     }


### PR DESCRIPTION
### Two Changes:
- 1st:
I made the affected depth of the mined area to always be one block, just like the original Terra Shatterer. If I wanted to mine a square room (with A tier) I often ended up mining on block too far because it just did that.  It was annoying to always place those blocks back.

- 2nd:
The Truncanator ability only activates when the tool is activated. I HAD TO REBUILD MY BASE 3 TIMES BECAUSE I MINED A PLANK NEXT TO A LOG AND MY BASE IS MADE FROM THAT! So now.. Less annoying.